### PR TITLE
fix: rust toolchain vars

### DIFF
--- a/.github/workflows/test-rust.yaml
+++ b/.github/workflows/test-rust.yaml
@@ -66,9 +66,9 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ inputs.toolchain }}
-          override: ${{ inputs.override }}
-          profile: ${{ inputs.profile }}
+          toolchain: ${{ inputs.toolchain_tc }}
+          override: ${{ inputs.toolchain_override }}
+          profile: ${{ inputs.toolchain_profile }}
 
       - name: Run tests
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Gjør at de matcher input variablene på L37-48.