### PR TITLE
kustomize deply: substitute GIT_COMMIT_SHORT_SHA

### DIFF
--- a/.github/workflows/kustomize-deploy.yaml
+++ b/.github/workflows/kustomize-deploy.yaml
@@ -122,7 +122,7 @@ jobs:
       - name: Deploy with kustomize
         run: |
           cd deploy/${{ inputs.environment }} 
-          sed -i "s/\$(GIT_COMMIT_SHA)/${{ github.sha }}/" kustomization.yaml
+          find deploy -name '*.yaml' | xargs sed -i "s/\$(GIT_COMMIT_SHA)/${{ github.sha }}/"
           if [[ "${{ inputs.image }}" != "" ]]; then kustomize edit set image app=${{ inputs.image }}; fi
           kustomize build > .build.yaml
           kubectl apply -f .build.yaml

--- a/.github/workflows/kustomize-deploy.yaml
+++ b/.github/workflows/kustomize-deploy.yaml
@@ -121,8 +121,8 @@ jobs:
 
       - name: Deploy with kustomize
         run: |
-          cd deploy/${{ inputs.environment }} 
           find deploy -name '*.yaml' | xargs sed -i "s/\$(GIT_COMMIT_SHA)/${{ github.sha }}/"
+          cd deploy/${{ inputs.environment }} 
           if [[ "${{ inputs.image }}" != "" ]]; then kustomize edit set image app=${{ inputs.image }}; fi
           kustomize build > .build.yaml
           kubectl apply -f .build.yaml

--- a/.github/workflows/kustomize-deploy.yaml
+++ b/.github/workflows/kustomize-deploy.yaml
@@ -122,7 +122,7 @@ jobs:
       - name: Deploy with kustomize
         run: |
           cd deploy/${{ inputs.environment }} 
-          sed -i "s/\$(GIT_COMMIT_SHORT_SHA)/${{ env.SHORT_SHA }}/" kustomization.yaml
+          sed -i "s/\$(GIT_COMMIT_SHORT_SHA)/${{ github.sha }}/" kustomization.yaml
           if [[ "${{ inputs.image }}" != "" ]]; then kustomize edit set image app=${{ inputs.image }}; fi
           kustomize build > .build.yaml
           kubectl apply -f .build.yaml

--- a/.github/workflows/kustomize-deploy.yaml
+++ b/.github/workflows/kustomize-deploy.yaml
@@ -122,7 +122,7 @@ jobs:
       - name: Deploy with kustomize
         run: |
           cd deploy/${{ inputs.environment }} 
-          sed -i "s/\$(GIT_COMMIT_SHORT_SHA)/${{ github.sha }}/" kustomization.yaml
+          sed -i "s/\$(GIT_COMMIT_SHA)/${{ github.sha }}/" kustomization.yaml
           if [[ "${{ inputs.image }}" != "" ]]; then kustomize edit set image app=${{ inputs.image }}; fi
           kustomize build > .build.yaml
           kubectl apply -f .build.yaml

--- a/.github/workflows/kustomize-deploy.yaml
+++ b/.github/workflows/kustomize-deploy.yaml
@@ -122,6 +122,7 @@ jobs:
       - name: Deploy with kustomize
         run: |
           cd deploy/${{ inputs.environment }} 
+          sed -i "s/\$(GIT_COMMIT_SHORT_SHA)/${{ env.SHORT_SHA }}/" kustomization.yaml
           if [[ "${{ inputs.image }}" != "" ]]; then kustomize edit set image app=${{ inputs.image }}; fi
           kustomize build > .build.yaml
           kubectl apply -f .build.yaml


### PR DESCRIPTION
Related to https://github.com/Informasjonsforvaltning/workflows/issues/63

Tanken er å bruke følgende i `kustomization.yaml`, så blir `$(GIT_COMMIT_SHA)` erstattet med sha

```yaml
images:
  - name: rdf-diff-writer
    newName: eu.gcr.io/digdir-fdk-infra/rdf-diff-writer
    newTag: $(GIT_COMMIT_SHA)
  - name: rdf-query-cache
    newName: eu.gcr.io/digdir-fdk-infra/rdf-query-cache
    newTag: $(GIT_COMMIT_SHA)
```