### PR TITLE
chore: pdf build continue-on-error input

### DIFF
--- a/.github/workflows/specification-upload-files.yaml
+++ b/.github/workflows/specification-upload-files.yaml
@@ -23,6 +23,10 @@ on:
       program_pdf:
         required: false
         type: string
+      program_pdf_continue_on_error:
+        required: false
+        type: boolean
+        default: false
       program:
         required: false
         type: string
@@ -77,6 +81,7 @@ jobs:
       - name: Build pdf
         id: adocbuild_pdf
         if: ${{ inputs.program_pdf != '' }}
+        continue-on-error: ${{ inputs.program_pdf_continue_on_error }}
         uses: docker://asciidoctor/docker-asciidoctor:1.106@sha256:6266e05784c2d8ece9d9fe5e593b12c3beebebbc467135fd6f4a56269c93cea3
         with:
           args: bash -ec "${{ inputs.program_pdf }}"


### PR DESCRIPTION
## Summary

Adds a `program_pdf_continue_on_error` input to `specification-upload-files.yaml`, letting callers tolerate a failing PDF build without failing the whole workflow.

## Why

PR #238 + follow-up `38c4617` changed the asciidoctor build steps from `bash -c` to `bash -ec`, adding fail-fast semantics. The `Build pdf` step now dies on the first failing command and aborts the job. Previously (`bash -c`), the script ran to the end and the step only surfaced the exit code of the *last* command, so a flaky PDF render was effectively tolerated. This is a behavior change for callers that relied on the old forgiving behavior.

## Change

- New `workflow_call` input `program_pdf_continue_on_error` (boolean, `default: false`).
- Applied to the `Build pdf` step via `continue-on-error: ${{ inputs.program_pdf_continue_on_error }}`.

Default `false` preserves current fail-fast behavior — non-breaking. Callers opt in:

```yaml
with:
  program_pdf: asciidoctor-pdf ...
  program_pdf_continue_on_error: true
```

The `-ec` fail-fast inside the script is retained; the input only governs whether the step's failure aborts the job. Scoped to the PDF step and `specification-upload-files.yaml` only.