### PR TITLE
chore: pdf build continue-on-error input (github-pages)

### DIFF
--- a/.github/workflows/specification-github-pages.yaml
+++ b/.github/workflows/specification-github-pages.yaml
@@ -15,6 +15,10 @@ on:
       program_pdf:
         required: false
         type: string
+      program_pdf_continue_on_error:
+        required: false
+        type: boolean
+        default: false
       program:
         required: false
         type: string
@@ -68,6 +72,7 @@ jobs:
     - name: Build pdf
       id: adocbuild_pdf
       if: ${{ inputs.program_pdf != '' }}
+      continue-on-error: ${{ inputs.program_pdf_continue_on_error }}
       uses: docker://asciidoctor/docker-asciidoctor:1.106@sha256:6266e05784c2d8ece9d9fe5e593b12c3beebebbc467135fd6f4a56269c93cea3
       with:
         args: bash -ec "${{ inputs.program_pdf }}"


### PR DESCRIPTION
## Summary

Mirrors #241 onto `specification-github-pages.yaml`: adds a `program_pdf_continue_on_error` input so callers can tolerate a failing PDF build without failing the whole workflow.

## Why

#241 added this only to `specification-upload-files.yaml`, but `specification-github-pages.yaml` has the identical `bash -ec` fail-fast PDF build step and the same behavior change for callers. This keeps the two spec workflows consistent.

## Change

- New `workflow_call` input `program_pdf_continue_on_error` (boolean, `default: false`).
- Applied to the `Build pdf` step via `continue-on-error: ${{ inputs.program_pdf_continue_on_error }}`.

Default `false` preserves current fail-fast behavior — non-breaking. Callers opt in with `program_pdf_continue_on_error: true`.